### PR TITLE
The app is buildable on Ubuntu 20.04

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,11 +24,11 @@
 
     <!-- Step 3:  compile all .java files, here we have four packages totally -->
     <target name="compile" depends="clean, init" description="compiling jgex">
-        <javac  srcdir="${src}/pdf" destdir="${dest}" debug="off" nowarn="on" />      
-        <javac  srcdir="${src}/UI" destdir="${dest}" debug="off" nowarn="on" />
-        <javac  srcdir="${src}/maths" destdir="${dest}" debug="off" nowarn="on" />
-        <javac  srcdir="${src}/gprover" destdir="${dest}" debug="off" nowarn="on" />
-        <javac  srcdir="${src}/wprover" destdir="${dest}" debug="off" nowarn="on" />
+        <javac  srcdir="${src}/pdf" destdir="${dest}" debug="off" nowarn="on" source="8" />      
+        <javac  srcdir="${src}/UI" destdir="${dest}" debug="off" nowarn="on" source="8" />
+        <javac  srcdir="${src}/maths" destdir="${dest}" debug="off" nowarn="on" source="8" />
+        <javac  srcdir="${src}/gprover" destdir="${dest}" debug="off" nowarn="on" source="8" />
+        <javac  srcdir="${src}/wprover" destdir="${dest}" debug="off" nowarn="on" source="8" />
     </target>
 
 

--- a/build.xml
+++ b/build.xml
@@ -56,7 +56,7 @@
     <target name="build" depends="compile, copy-images" description="building jgex">
 <!--         <delete dir="${out}"/>
         <mkdir dir="${out}"/>   -->
-        <jar jarfile="${out}/${jgex_jar}" manifest="./MANIFEST.MF" basedir="${dest}"/>
+        <jar jarfile="${out}/${jgex_jar}" manifest="./manifest.mf" basedir="${dest}"/>
     </target>
 
 


### PR DESCRIPTION
Fixed two issues:

1) added `sources="8"` to force the java sources version. Contemporary (java 11) compiler fails as `var` is a keyword nowadays;
2) `MANIFEST.MF` is not visible on Linux as the filesystem is case-sensitive, and the real name of the file is `manifest.mf`.